### PR TITLE
fix circular reference in moving average query

### DIFF
--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryToolChest.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageQueryToolChest.java
@@ -44,7 +44,7 @@ import java.util.Map;
 public class MovingAverageQueryToolChest extends QueryToolChest<Row, MovingAverageQuery>
 {
 
-  private final QuerySegmentWalker walker;
+  private final Provider<QuerySegmentWalker> walkerProvider;
   private final RequestLogger requestLogger;
 
   private final MovingAverageQueryMetricsFactory movingAverageQueryMetricsFactory;
@@ -53,14 +53,13 @@ public class MovingAverageQueryToolChest extends QueryToolChest<Row, MovingAvera
    * Construct a MovingAverageQueryToolChest for processing moving-average queries.
    * MovingAverage queries are expected to be processed on broker nodes and never hit historical nodes.
    *
-   * @param walker
+   * @param walkerProvider
    * @param requestLogger
    */
   @Inject
-  public MovingAverageQueryToolChest(Provider<QuerySegmentWalker> walker, RequestLogger requestLogger)
+  public MovingAverageQueryToolChest(Provider<QuerySegmentWalker> walkerProvider, RequestLogger requestLogger)
   {
-
-    this.walker = walker.get();
+    this.walkerProvider = walkerProvider;
     this.requestLogger = requestLogger;
     this.movingAverageQueryMetricsFactory = DefaultMovingAverageQueryMetricsFactory.instance();
   }
@@ -68,7 +67,7 @@ public class MovingAverageQueryToolChest extends QueryToolChest<Row, MovingAvera
   @Override
   public QueryRunner<Row> mergeResults(QueryRunner<Row> runner)
   {
-    return new MovingAverageQueryRunner(walker, requestLogger);
+    return new MovingAverageQueryRunner(walkerProvider.get(), requestLogger);
   }
 
   @Override


### PR DESCRIPTION
Fixes #7999.

(Replace XXXX with the id of the issue fixed in this PR. Remove the above line if there is no corresponding
issue. Don't reference the issue in the title of this pull-request.)

(If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers.)

### Description

Fix circular reference in moving average query to avoid broker start failed when druid moving average query extension is loaded.

Describe your patch: 
the origin bug fix for break circular reference is wrong way.

If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For
example:
#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such
   as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)

It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point
and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the
advantages of the chosen designs and names.

If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any
other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain
what have changed in your final design compared to your original proposal or the consensus version in the end of the
discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those
aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description.

Some of the aspects mentioned above may be omitted for simple and small changes.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.

Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the
items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary,
but it would be very helpful if you at least self-review the PR.

<hr>

For reviewers: the key changed/added classes in this PR are `MyFoo`, `OurBar`, and `TheirBaz`.

(Add this section in big PRs to ease navigation in them for reviewers.)